### PR TITLE
feat: add watch-later page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
 import "./styles.css";
 import { Routes, Route } from "react-router-dom";
 import Mockman from "mockman-js";
-import {Home, Videos, LikedVideos} from "./pages";
+import { Home, Videos, LikedVideos, WatchLater } from "./pages";
 import { useAsyncFetch, useLogin } from "./hooks";
 import { Navbar } from "./components";
 import { useEffect } from "react";
-import { getLikedVideos } from "./utils";
+import { getLikedVideos, getWatchLaterVideos } from "./utils";
 import { useVideos } from "./context/video-context";
 
 function App() {
@@ -27,6 +27,7 @@ function App() {
 
   useEffect(()=>{
     getLikedVideos(dispatch);
+    getWatchLaterVideos(dispatch);
   },[])
 
   return (
@@ -36,6 +37,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/videos" element={<Videos/>} />
         <Route path="/liked" element={<LikedVideos/>} />
+        <Route path="/watchlater" element={<WatchLater />} />
         <Route path="/mockman" element={<Mockman />} />
       </Routes>
     </div>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -21,7 +21,7 @@ export function Navbar(){
                 {[{linkTo:"/videos", linkFor:"Explore"},
                 {linkTo:"/playlists", linkFor:"Playlists"},
                 {linkTo:"/liked", linkFor:"Liked"},
-                {linkTo:"/watch-later", linkFor:"Watch Later"}].map(({linkTo, linkFor}) => 
+                {linkTo:"/watchlater", linkFor:"Watch Later"}].map(({linkTo, linkFor}) => 
                 <li key={linkTo}><Link to={linkTo} className="btn btn-secondary-link">{linkFor}</Link></li>)}
             </ul>
         </nav>

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -1,6 +1,9 @@
 import "./video-card.css"
 import {useVideos} from "../../context/video-context";
-import { addToLikedVideos, removeFromLikedVideos } from "../../utils";
+import { 
+    addToLikedVideos, removeFromLikedVideos, 
+    addToWatchLaterVideos, removeFromWatchLaterVideos
+} from "../../utils";
 
 export function VideoCard({value}){
     const {_id, title, creator, views, uploaded, thumbnail} = value;
@@ -9,6 +12,9 @@ export function VideoCard({value}){
     return (
         <div className="card card-vertical">
             <i className="far fa-heart"></i>
+            {state.watchLaterVideos.find(item=>item._id===_id)
+            ? <i className="fas fa-heart" onClick={()=>removeFromWatchLaterVideos(_id, dispatch)} ></i>
+            : <i className="far fa-heart" onClick={()=>addToWatchLaterVideos(value, dispatch)}></i>}
             <img src={thumbnail.src} className="img-responsive" alt={thumbnail.alt} />
             <div className="card-content">
                 <h6 className="card-title">{title}</h6>

--- a/src/components/VideoCard/video-card.css
+++ b/src/components/VideoCard/video-card.css
@@ -59,3 +59,7 @@
 .btn-like-dislike-wrapper .fas.fa-thumbs-up{
     color: var(--primary-color);
 }
+
+.card-vertical .fas.fa-heart{
+    color: #ff4343;
+}

--- a/src/context/video-context.js
+++ b/src/context/video-context.js
@@ -7,7 +7,8 @@ const initialState = {
     videos: [],
     categories: [],
     categoryFilter: "All",
-    likedVideos: []
+    likedVideos: [],
+    watchLaterVideos: []
 }
 
 const VideoProvider = ({children}) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
 export {Home} from "./home/Home";
 export {Videos} from "./video-listing/Videos";
 export {LikedVideos} from "./liked-videos/LikedVideos";
+export {WatchLater} from "./watch-later/WatchLater";

--- a/src/pages/liked-videos/liked-videos.css
+++ b/src/pages/liked-videos/liked-videos.css
@@ -1,7 +1,0 @@
-.liked-videos-card-wrapper{
-    margin: 2rem 0;
-}
-
-.liked-videos-card-wrapper h2{
-    text-align: center;
-}

--- a/src/pages/watch-later/WatchLater.jsx
+++ b/src/pages/watch-later/WatchLater.jsx
@@ -1,14 +1,14 @@
 import { VideoCard } from "../../components";
 import {useVideos} from "../../context/video-context";
 
-export function LikedVideos(){
+export function WatchLater(){
     const {state} = useVideos();
     
     return (
         <div className="videos-card-wrapper">
-            <h2>Liked Videos ({state.likedVideos.length})</h2>
+            <h2>Watch Later Videos ({state.watchLaterVideos.length})</h2>
             <div className="video-cards-container">
-            {state.likedVideos.map(item=><VideoCard key={item._id} value={item} />)}
+            {state.watchLaterVideos.map(item=><VideoCard key={item._id} value={item} />)}
             </div>
         </div>
     );

--- a/src/reducer/video-reducer.js
+++ b/src/reducer/video-reducer.js
@@ -8,5 +8,7 @@ export function videoReducer(state, action){
             return {...state, categoryFilter: action.payload};
         case "SET_LIKED_VIDEOS":
             return {...state, likedVideos: action.payload};
+        case "SET_WATCH_LATER_VIDEOS":
+            return {...state, watchLaterVideos: action.payload};
     }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,3 +22,11 @@ button{
     grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
     justify-items: center;    
 }
+
+.videos-card-wrapper{
+    margin: 2rem 0;
+}
+
+.videos-card-wrapper h2{
+    text-align: center;
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,5 @@
 export {getFilteredVideos} from "./filterVideos";
-export {getLikedVideos, addToLikedVideos, removeFromLikedVideos} from "./serverRequests";
+export {
+    getLikedVideos, addToLikedVideos, removeFromLikedVideos, 
+    getWatchLaterVideos, addToWatchLaterVideos, removeFromWatchLaterVideos
+} from "./serverRequests";

--- a/src/utils/serverRequests.js
+++ b/src/utils/serverRequests.js
@@ -45,3 +45,49 @@ export const removeFromLikedVideos = async(id, dispatch) => {
         console.log(err);
     }
 }
+
+export const getWatchLaterVideos = async(dispatch) => {
+  try{
+    const {status, data} = await axios({
+      method: "get",
+      url: "/api/user/watchlater",
+      headers: {authorization: localStorage.getItem("encodedToken")}
+    });
+    if(status===200){
+      dispatch({type:"SET_WATCH_LATER_VIDEOS", payload: data.watchlater})
+    }
+  }catch(err){
+    console.log(err);
+  }
+}
+
+export const addToWatchLaterVideos = async(postData, dispatch) => {
+  try{
+      const {status, data} = await axios({
+        method: "post",
+        url: "/api/user/watchlater",
+        data: {video: postData},
+        headers: {authorization: localStorage.getItem("encodedToken")}
+      });
+      if(status===201){
+        dispatch({type:"SET_WATCH_LATER_VIDEOS", payload: data.watchlater})
+      }
+  }catch(err){
+      console.log(err);
+  }
+}
+
+export const removeFromWatchLaterVideos = async(id, dispatch) => {
+  try{
+      const {status, data} = await axios({
+        method: "delete",
+        url: `/api/user/watchlater/${id}`,
+        headers: {authorization: localStorage.getItem("encodedToken")}
+      });
+      if(status===200){
+        dispatch({type:"SET_WATCH_LATER_VIDEOS", payload: data.watchlater})
+      }
+  }catch(err){
+      console.log(err);
+  }
+}


### PR DESCRIPTION
## Watch Later Videos Page
I have added the Watch Later Videos page. Ignore the index files. Focus only on the components, pages & context + reducer files.
 
### Live Preview - [Watch Later Videos Page](https://deploy-preview-6--vacay-stream.netlify.app/)

### Use this link - [Link for files](https://github.com/anik31/vacay-stream/pull/6/files?file-filters%5B%5D=.js&file-filters%5B%5D=.jsx&show-viewed-files=true&show-deleted-files=false) (Doesn't contain CSS & deleted files)

## Files to check
- src/components/VideoCard/VideoCard.jsx
- src/pages/liked-videos/WatchLater.jsx
- src/reducer/video-reducer.js
- src/utils/serverRequests.js
 
 _PS - Ignore other files._
 
https://user-images.githubusercontent.com/56336326/160448935-636429e0-a758-4024-84d2-5b0227e1b3ae.mp4