### PR TITLE
feat: add history page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
 import "./styles.css";
 import { Routes, Route } from "react-router-dom";
 import Mockman from "mockman-js";
-import { Home, Videos, LikedVideos, WatchLater } from "./pages";
+import { Home, Videos, LikedVideos, WatchLater, History } from "./pages";
 import { useAsyncFetch, useLogin } from "./hooks";
 import { Navbar } from "./components";
 import { useEffect } from "react";
-import { getLikedVideos, getWatchLaterVideos } from "./utils";
+import { getLikedVideos, getWatchHistory, getWatchLaterVideos } from "./utils";
 import { useVideos } from "./context/video-context";
 
 function App() {
@@ -28,6 +28,7 @@ function App() {
   useEffect(()=>{
     getLikedVideos(dispatch);
     getWatchLaterVideos(dispatch);
+    getWatchHistory(dispatch);
   },[])
 
   return (
@@ -38,6 +39,7 @@ function App() {
         <Route path="/videos" element={<Videos/>} />
         <Route path="/liked" element={<LikedVideos/>} />
         <Route path="/watchlater" element={<WatchLater />} />
+        <Route path="/history" element={<History />} />
         <Route path="/mockman" element={<Mockman />} />
       </Routes>
     </div>

--- a/src/components/Cards/HistoryCard.jsx
+++ b/src/components/Cards/HistoryCard.jsx
@@ -17,14 +17,6 @@ export function HistoryCard({value}){
                     <span className="text-gray text-sm">{views} views</span>
                     <span className="dot-separator text-gray"> • </span>
                     <span className="text-gray text-sm">{uploaded} ago</span>
-                    {/* <div className="btn-like-dislike-wrapper">
-                        <button>
-                        {state.likedVideos.find(item=>item._id===_id)
-                        ? <i className="fas fa-thumbs-up" onClick={()=>removeFromLikedVideos(_id, dispatch)} ></i>
-                        : <i className="far fa-thumbs-up" onClick={()=>addToLikedVideos(value, dispatch)}></i>}
-                        </button>
-                        <button><i className="far fa-thumbs-down"></i></button>
-                    </div> */}
                 </div>
             </div>
             <button className="btn btn-primary">Watch Now</button>

--- a/src/components/Cards/HistoryCard.jsx
+++ b/src/components/Cards/HistoryCard.jsx
@@ -1,20 +1,14 @@
 import "./video-card.css"
 import {useVideos} from "../../context/video-context";
-import { 
-    addToLikedVideos, removeFromLikedVideos, 
-    addToWatchLaterVideos, removeFromWatchLaterVideos
-} from "../../utils";
+import { removeFromWatchHistory } from "../../utils";
 
-export function VideoCard({value}){
+export function HistoryCard({value}){
     const {_id, title, creator, views, uploaded, thumbnail} = value;
     const {state, dispatch} = useVideos();
 
     return (
         <div className="card card-vertical">
-            <i className="far fa-heart"></i>
-            {state.watchLaterVideos.find(item=>item._id===_id)
-            ? <i className="fas fa-heart" onClick={()=>removeFromWatchLaterVideos(_id, dispatch)} ></i>
-            : <i className="far fa-heart" onClick={()=>addToWatchLaterVideos(value, dispatch)}></i>}
+            <i className="fas fa-trash" onClick={()=>removeFromWatchHistory(_id, dispatch)} ></i>
             <img src={thumbnail.src} className="img-responsive" alt={thumbnail.alt} />
             <div className="card-content">
                 <h6 className="card-title">{title}</h6>
@@ -23,14 +17,14 @@ export function VideoCard({value}){
                     <span className="text-gray text-sm">{views} views</span>
                     <span className="dot-separator text-gray"> • </span>
                     <span className="text-gray text-sm">{uploaded} ago</span>
-                    <div className="btn-like-dislike-wrapper">
+                    {/* <div className="btn-like-dislike-wrapper">
                         <button>
                         {state.likedVideos.find(item=>item._id===_id)
                         ? <i className="fas fa-thumbs-up" onClick={()=>removeFromLikedVideos(_id, dispatch)} ></i>
                         : <i className="far fa-thumbs-up" onClick={()=>addToLikedVideos(value, dispatch)}></i>}
                         </button>
                         <button><i className="far fa-thumbs-down"></i></button>
-                    </div>
+                    </div> */}
                 </div>
             </div>
             <button className="btn btn-primary">Watch Now</button>

--- a/src/components/Cards/VideoCard.jsx
+++ b/src/components/Cards/VideoCard.jsx
@@ -1,0 +1,40 @@
+import "./video-card.css"
+import {useVideos} from "../../context/video-context";
+import { 
+    addToLikedVideos, removeFromLikedVideos, 
+    addToWatchLaterVideos, removeFromWatchLaterVideos,
+    addToWatchHistory
+} from "../../utils";
+
+export function VideoCard({value}){
+    const {_id, title, creator, views, uploaded, thumbnail} = value;
+    const {state, dispatch} = useVideos();
+
+    return (
+        <div className="card card-vertical">
+            <i className="far fa-heart"></i>
+            {state.watchLaterVideos.find(item=>item._id===_id)
+            ? <i className="fas fa-heart" onClick={()=>removeFromWatchLaterVideos(_id, dispatch)} ></i>
+            : <i className="far fa-heart" onClick={()=>addToWatchLaterVideos(value, dispatch)}></i>}
+            <img src={thumbnail.src} className="img-responsive" alt={thumbnail.alt} />
+            <div className="card-content">
+                <h6 className="card-title">{title}</h6>
+                <span className="text-gray text-sm">{creator}</span>
+                <div className="video-metrics">
+                    <span className="text-gray text-sm">{views} views</span>
+                    <span className="dot-separator text-gray"> • </span>
+                    <span className="text-gray text-sm">{uploaded} ago</span>
+                    <div className="btn-like-dislike-wrapper">
+                        <button>
+                        {state.likedVideos.find(item=>item._id===_id)
+                        ? <i className="fas fa-thumbs-up" onClick={()=>removeFromLikedVideos(_id, dispatch)} ></i>
+                        : <i className="far fa-thumbs-up" onClick={()=>addToLikedVideos(value, dispatch)}></i>}
+                        </button>
+                        <button><i className="far fa-thumbs-down"></i></button>
+                    </div>
+                </div>
+            </div>
+            <button className="btn btn-primary" onClick={()=>addToWatchHistory(value, dispatch)}>Watch Now</button>
+        </div>
+    );
+}

--- a/src/components/Cards/video-card.css
+++ b/src/components/Cards/video-card.css
@@ -40,7 +40,7 @@
     height: 2rem;
 }
 
-.card-vertical .fa-heart{
+.card-vertical .fa-heart, .card-vertical .fa-trash{
     background-color: white;
     border-radius: 50%;
     padding: 0.5rem;
@@ -62,4 +62,11 @@
 
 .card-vertical .fas.fa-heart{
     color: #ff4343;
+}
+
+.card .fa-trash{
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    cursor: pointer;
 }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -21,7 +21,8 @@ export function Navbar(){
                 {[{linkTo:"/videos", linkFor:"Explore"},
                 {linkTo:"/playlists", linkFor:"Playlists"},
                 {linkTo:"/liked", linkFor:"Liked"},
-                {linkTo:"/watchlater", linkFor:"Watch Later"}].map(({linkTo, linkFor}) => 
+                {linkTo:"/watchlater", linkFor:"Watch Later"},
+                {linkTo:"/history", linkFor:"History"}].map(({linkTo, linkFor}) => 
                 <li key={linkTo}><Link to={linkTo} className="btn btn-secondary-link">{linkFor}</Link></li>)}
             </ul>
         </nav>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
-export {VideoCard} from "./VideoCard/VideoCard";
+export {VideoCard} from "./Cards/VideoCard";
+export {HistoryCard} from "./Cards/HistoryCard";
 export {Navbar} from "./Navbar/Navbar";

--- a/src/context/video-context.js
+++ b/src/context/video-context.js
@@ -8,7 +8,8 @@ const initialState = {
     categories: [],
     categoryFilter: "All",
     likedVideos: [],
-    watchLaterVideos: []
+    watchLaterVideos: [],
+    history: []
 }
 
 const VideoProvider = ({children}) => {

--- a/src/pages/history/History.jsx
+++ b/src/pages/history/History.jsx
@@ -1,0 +1,18 @@
+import { HistoryCard } from "../../components";
+import {useVideos} from "../../context/video-context";
+import { removeAllWatchHistory } from "../../utils";
+import "./history.css";
+
+export function History(){
+    const {state, dispatch} = useVideos();
+    
+    return (
+        <div className="videos-card-wrapper">
+            <h2>Watch History</h2>
+            <button className="btn btn-primary-outline" onClick={()=>removeAllWatchHistory(dispatch)}>Clear Full History</button>
+            <div className="video-cards-container">
+            {state.history.map(item=><HistoryCard key={item._id} value={item} />)}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/history/history.css
+++ b/src/pages/history/history.css
@@ -1,0 +1,4 @@
+.videos-card-wrapper .btn{
+    margin-left: auto;
+    margin-right: 2rem;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,3 +2,4 @@ export {Home} from "./home/Home";
 export {Videos} from "./video-listing/Videos";
 export {LikedVideos} from "./liked-videos/LikedVideos";
 export {WatchLater} from "./watch-later/WatchLater";
+export {History} from "./history/History";

--- a/src/reducer/video-reducer.js
+++ b/src/reducer/video-reducer.js
@@ -10,5 +10,7 @@ export function videoReducer(state, action){
             return {...state, likedVideos: action.payload};
         case "SET_WATCH_LATER_VIDEOS":
             return {...state, watchLaterVideos: action.payload};
+        case "SET_HISTORY":
+            return {...state, history: action.payload};
     }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 export {getFilteredVideos} from "./filterVideos";
 export {
     getLikedVideos, addToLikedVideos, removeFromLikedVideos, 
-    getWatchLaterVideos, addToWatchLaterVideos, removeFromWatchLaterVideos
+    getWatchLaterVideos, addToWatchLaterVideos, removeFromWatchLaterVideos,
+    getWatchHistory, addToWatchHistory, removeFromWatchHistory, removeAllWatchHistory
 } from "./serverRequests";

--- a/src/utils/serverRequests.js
+++ b/src/utils/serverRequests.js
@@ -91,3 +91,64 @@ export const removeFromWatchLaterVideos = async(id, dispatch) => {
       console.log(err);
   }
 }
+
+export const getWatchHistory = async(dispatch) => {
+  try{
+    const {status, data} = await axios({
+      method: "get",
+      url: "/api/user/history",
+      headers: {authorization: localStorage.getItem("encodedToken")}
+    });
+    if(status===200){
+      dispatch({type:"SET_HISTORY", payload: data.history})
+    }
+  }catch(err){
+    console.log(err);
+  }
+}
+
+export const addToWatchHistory = async(postData, dispatch) => {
+  try{
+      const {status, data} = await axios({
+        method: "post",
+        url: "/api/user/history",
+        data: {video: postData},
+        headers: {authorization: localStorage.getItem("encodedToken")}
+      });
+      if(status===201){
+        dispatch({type:"SET_HISTORY", payload: data.history})
+      }
+  }catch(err){
+      console.log(err);
+  }
+}
+
+export const removeFromWatchHistory = async(id, dispatch) => {
+  try{
+      const {status, data} = await axios({
+        method: "delete",
+        url: `/api/user/history/${id}`,
+        headers: {authorization: localStorage.getItem("encodedToken")}
+      });
+      if(status===200){
+        dispatch({type:"SET_HISTORY", payload: data.history})
+      }
+  }catch(err){
+      console.log(err);
+  }
+}
+
+export const removeAllWatchHistory = async(dispatch) => {
+  try{
+      const {status, data} = await axios({
+        method: "delete",
+        url: `/api/user/history/all`,
+        headers: {authorization: localStorage.getItem("encodedToken")}
+      });
+      if(status===200){
+        dispatch({type:"SET_HISTORY", payload: data.history})
+      }
+  }catch(err){
+      console.log(err);
+  }
+}


### PR DESCRIPTION
## Watch History Page
I have added the Watch History page. Ignore the index & CSS files. Focus only on the components, pages & context + reducer files.

### Note - I have not implemented single video page. So, the videos are being added to watch history by clicking on watch now button.
 
### Live Preview - [Watch History Page](https://deploy-preview-7--vacay-stream.netlify.app/)

## Files to check
- src/components/Cards/HistoryCard.jsx
- src/components/Cards/VideoCard.jsx
- src/context/video-context.js
- src/pages/history/History.jsx
- src/reducer/video-reducer.js
- src/utils/serverRequests.js
 
 _PS - Ignore other files._
 
https://user-images.githubusercontent.com/56336326/160654399-16db1814-8407-49d2-bcf9-9dd643e07fed.mp4